### PR TITLE
Install dev tools in devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -69,5 +69,7 @@
         "ultram4rine.sqltools-clickhouse-driver"
     ],
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
-    "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009]
+    "forwardPorts": [8000, 5432, 6379, 8123, 8234, 9000, 9092, 9440, 9009],
+    // Install required tools after container creation
+    "postCreateCommand": "bash -c 'curl -LsSf https://astral.sh/uv/install.sh | sh && curl --proto \"=https\" --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source ~/.cargo/env && cargo install sqlx-cli mprocs'"
 }


### PR DESCRIPTION
## Problem

Users following the "Developing with Codespaces" guide currently need to manually install `uv`, `rust`, `sqlx-cli`, and `mprocs`. This PR aims to streamline the setup process by automating the installation of these tools.

## Changes

Adds a `postCreateCommand` to `.devcontainer/devcontainer.json` to automatically install:
- `uv`
- `rust`
- `sqlx-cli`
- `mprocs`

## How did you test this code?

This change addresses a user-reported issue where these tools required manual installation during Codespace setup. The fix was implemented based on the user's feedback, and the expected outcome is that these tools are now automatically available upon Codespace creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-b01bf2f9-c757-4f83-825e-fb47f09d6ea6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b01bf2f9-c757-4f83-825e-fb47f09d6ea6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

