### PR TITLE
Add project name to alert emails

### DIFF
--- a/posthog/tasks/alerts/test/test_alert_checks.py
+++ b/posthog/tasks/alerts/test/test_alert_checks.py
@@ -341,6 +341,11 @@ class TestAlertChecks(APIBaseTest, ClickhouseDestroyTablesMixin):
         assert email.to[0]["recipient"] == "user1@posthog.com"
         assert "first anomaly description" in email.html_body
         assert "second anomaly description" in email.html_body
+        
+        # Test that project name appears in subject and email body
+        project_name = alert.team.project.name
+        assert f"[{project_name}]" in email.subject
+        assert f"[{project_name}]" in email.html_body
 
     def test_alert_not_recalculated_when_not_due(
         self, mock_send_notifications_for_breaches: MagicMock, mock_send_errors: MagicMock

--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -162,7 +162,8 @@ def trigger_alert_hog_functions(alert: AlertConfiguration, properties: dict) -> 
 def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[str]) -> None:
     email_targets = alert.subscribed_users.all().values_list("email", flat=True)
     if email_targets:
-        subject = f"PostHog alert {alert.name} is firing"
+        project_name = alert.team.project.name
+        subject = f"PostHog alert {alert.name} is firing [{project_name}]"
         campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
         insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
         alert_url = f"{insight_url}?alert_id={alert.id}"
@@ -176,6 +177,7 @@ def send_notifications_for_breaches(alert: AlertConfiguration, breaches: list[st
                 "insight_name": alert.insight.name,
                 "alert_url": alert_url,
                 "alert_name": alert.name,
+                "project_name": project_name,
             },
         )
 
@@ -192,7 +194,8 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     logger.info("Sending alert error notifications", alert_id=alert.id, error=error)
 
     # TODO: uncomment this after checking errors sent
-    # subject = f"PostHog alert {alert.name} check failed to evaluate"
+    # project_name = alert.team.project.name
+    # subject = f"PostHog alert {alert.name} check failed to evaluate [{project_name}]"
     # campaign_key = f"alert-firing-notification-{alert.id}-{timezone.now().timestamp()}"
     # insight_url = f"/project/{alert.team.pk}/insights/{alert.insight.short_id}"
     # alert_url = f"{insight_url}?alert_id={alert.id}"
@@ -206,6 +209,7 @@ def send_notifications_for_errors(alert: AlertConfiguration, error: dict) -> Non
     #         "insight_name": alert.insight.name,
     #         "alert_url": alert_url,
     #         "alert_name": alert.name,
+    #         "project_name": project_name,
     #     },
     # )
     # targets = alert.subscribed_users.all().values_list("email", flat=True)

--- a/posthog/templates/email/alert_check_failed_to_evaluate.html
+++ b/posthog/templates/email/alert_check_failed_to_evaluate.html
@@ -1,6 +1,6 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
-        The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert failed to evaluate for insight <a
+        [{{ project_name }}] The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert failed to evaluate for insight <a
             href="{% absolute_uri insight_url %}">{{ insight_name }}</> with the error, below. There could be something wrong with the alert or the insight config.
     </p>
     <p><i>{{ alert_error }}</i></p>

--- a/posthog/templates/email/alert_check_firing.html
+++ b/posthog/templates/email/alert_check_firing.html
@@ -1,6 +1,6 @@
 {% extends "email/base.html" %} {% load posthog_assets %} {% block section %}
     <p>
-        The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert is firing for <a
+        [{{ project_name }}] The <a href="{% absolute_uri alert_url %}">{{ alert_name }}</a> alert is firing for <a
             href="{% absolute_uri insight_url %}">{{ insight_name }}</a>:
     </p>
     <ul>


### PR DESCRIPTION
## Problem

Users with multiple PostHog projects currently receive alert emails without any indication of which project the alert originates from. This makes it difficult to quickly identify the relevant project and prevents effective email filtering.

This change addresses the need for clear project identification in alert emails, enabling users to easily triage and filter alerts.

## Changes

This PR adds the project name to alert email titles and the first line of the email body.

-   **Email Subject**: The subject line for firing alerts now includes `[<project-name>]` at the end (e.g., "PostHog alert My Alert is firing [My Project]"). The commented-out error notification subject was also updated for consistency.
-   **Email Content**: The first line of both firing and failed evaluation alert emails now starts with `[{{ project_name }}]` (e.g., "[My Project] The My Alert alert is firing...").
-   **Test Update**: An existing alert email test was updated to assert that the project name is present in both the email subject and HTML body.

## How did you test this code?

An existing alert email test (`test_alert_email_with_multiple_breaches`) was updated to include assertions verifying that the project name is correctly added to both the email subject and the HTML body.

---
<a href="https://cursor.com/background-agent?bcId=bc-bc1e5632-0e44-4f36-8291-d648f18c69c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bc1e5632-0e44-4f36-8291-d648f18c69c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Alert notification emails now include the project name in square brackets in the subject and message, making it easier to identify which project an alert pertains to.
  - Both “alert firing” and “failed to evaluate” email templates display the project name alongside the alert information for clearer context.
- Bug Fixes
  - Improved consistency of alert email content to ensure project context appears reliably across subjects and bodies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->